### PR TITLE
Replace pytz with zoneinfo to avoid blocking I/O in async context

### DIFF
--- a/custom_components/train_traveler/coordinator.py
+++ b/custom_components/train_traveler/coordinator.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from datetime import timedelta, datetime
+from datetime import timedelta, datetime, timezone
 import logging
-import pytz
+from zoneinfo import ZoneInfo
 
 import async_timeout
 
@@ -30,7 +30,6 @@ from sncf.repositories.journey_repository import ApiJourneyRepository
 from sncf.repositories.stop_area_repository import ApiStopAreaRepository
 from sncf.repositories.disruption_repository import ApiDisruptionRepository
 
-
 from sncf.connections.connection_manager import ApiConnectionManager
 from sncf.services.journey_service import JourneyService
 
@@ -44,7 +43,7 @@ class JourneyCoordinator(DataUpdateCoordinator):
     def __init__(self, connection: ApiConnectionManager, hass: HomeAssistant, entry: ConfigEntry, last_journey: bool = False):
         self.config = entry.data
         
-        # set update_interval to 6hours if we are going to fetch last journey (to reduce useless api call)
+        # set update_interval to 6 hours if we are going to fetch last journey (to reduce useless API calls)
         update_interval = 21600
         if not last_journey:
             update_interval = self.config[CONF_SCAN_INTERVAL]
@@ -80,13 +79,14 @@ class JourneyCoordinator(DataUpdateCoordinator):
             self.config[CONF_END_AREA][CONF_AREA_COORD]
         )
 
-        self._timezone = pytz.timezone("Europe/Paris")
+        # Use ZoneInfo instead of pytz to avoid blocking I/O in async context
+        self._timezone = ZoneInfo("Europe/Paris")
         self._pause_update = False
         self._pause_interval = None
         self._next_journeys = None
 
         # Added for retrocompatibility
-        if not CONF_PAUSE_UPDATE_EXPERIMENTAL in self.config:
+        if CONF_PAUSE_UPDATE_EXPERIMENTAL not in self.config:
             self._conf_pause_update_experimental = False
         else:
             self._conf_pause_update_experimental = self.config[CONF_PAUSE_UPDATE_EXPERIMENTAL]
@@ -102,14 +102,19 @@ class JourneyCoordinator(DataUpdateCoordinator):
                         self.end_area
                     )
                 else:
-
                     if self._pause_update:
-                        if datetime.now().astimezone(pytz.utc) > self._pause_interval.astimezone(pytz.utc):
-                            _LOGGER.debug("Pause is now resumed as the next journey is in less than one hour : %s", self._pause_interval)
+                        if datetime.now(timezone.utc) > self._pause_interval.astimezone(timezone.utc):
+                            _LOGGER.debug(
+                                "Pause is now resumed as the next journey is in less than one hour : %s",
+                                self._pause_interval
+                            )
                             self._pause_update = False
                             self._pause_interval = None
                         else:
-                            _LOGGER.debug("Update is paused because the next journey is the next day and in more than one hour : %s", self._pause_interval)
+                            _LOGGER.debug(
+                                "Update is paused because the next journey is the next day and in more than one hour : %s",
+                                self._pause_interval
+                            )
                             journeys = self._next_journeys
 
                     if not self._pause_update: 
@@ -124,20 +129,22 @@ class JourneyCoordinator(DataUpdateCoordinator):
                         if self._conf_pause_update_experimental:
                             _LOGGER.debug("Pause update configuration enabled")
                             self._next_journeys = journeys
-                            next_departure_journey = self._timezone.localize(journeys.journeys[0].journey.departure_date_time).astimezone(pytz.utc)
+
+                            # Convert departure datetime (naive -> aware)
+                            departure_local = journeys.journeys[0].journey.departure_date_time.replace(tzinfo=self._timezone)
+                            next_departure_journey = departure_local.astimezone(timezone.utc)
                         
-                            if next_departure_journey.date() == (datetime.now().astimezone(pytz.utc).date() + timedelta(days=1)):
+                            if next_departure_journey.date() == (datetime.now(timezone.utc).date() + timedelta(days=1)):
                                 self._pause_update = True
                                 self._pause_interval = next_departure_journey - timedelta(hours=1)
-                                _LOGGER.debug("Pausing update because the next journey is the next day and in more than one hour : %s", self._pause_interval)
-
+                                _LOGGER.debug(
+                                    "Pausing update because the next journey is the next day and in more than one hour : %s",
+                                    self._pause_interval
+                                )
 
                 _LOGGER.debug("Api calls count %s", self.repository_manager._query_count)
-                
-                _LOGGER.info("data sucessfully fetched")
+                _LOGGER.info("Data successfully fetched")
                 return journeys
         except Exception as err:
             _LOGGER.error("Failed to fetch API : %s", err)
-            raise UpdateFailed(f"Error fetching api data: {err}")
-        
-    
+            raise UpdateFailed(f"Error fetching API data: {err}")

--- a/custom_components/train_traveler/journey_entity.py
+++ b/custom_components/train_traveler/journey_entity.py
@@ -1,5 +1,5 @@
 import logging
-import pytz
+from zoneinfo import ZoneInfo
 
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.core import callback
@@ -21,7 +21,7 @@ class JourneyBaseEntity(CoordinatorEntity):
         self.start_label = self.coordinator.data.start.label
         self.end_label = self.coordinator.data.end.label
         self.data = self.coordinator.data.journeys[self.index]
-        self.timezone = pytz.timezone("Europe/Paris")
+        self.timezone = ZoneInfo("Europe/Paris")
 
         _LOGGER.debug("Init %s Journey #%s %s - %s", self.type, (self.index + 1), self.start_label, self.end_label)
 

--- a/custom_components/train_traveler/sensor.py
+++ b/custom_components/train_traveler/sensor.py
@@ -58,11 +58,11 @@ class NextJourneyEntity(JourneyBaseEntity, SensorEntity):
         super().__init__(coordinator, index, type)
 
         self._attr_unique_id = f"{self.short_start_name()}_{self.short_end_name()}_{self.type}_journey_{self.index + 1}"
-        self._attr_native_value = self.timezone.localize(self.data.journey.departure_date_time)
+        self._attr_native_value = self.data.journey.departure_date_time.replace(tzinfo=self.timezone)
 
     def _handle_journey_update(self) -> None:
         _LOGGER.debug("[%s] updating: %s - %s", type(self).__name__, self.start_label, self.end_label)
-        self._attr_native_value = self.timezone.localize(self.data.journey.departure_date_time)
+        self._attr_native_value = self.data.journey.departure_date_time.replace(tzinfo=self.timezone)
         self.async_write_ha_state()
 
     @property
@@ -74,8 +74,8 @@ class NextJourneyEntity(JourneyBaseEntity, SensorEntity):
         return {
             ATTR_LINE_JOURNEY: self.data.journey.sections[0].informations.label,
             ATTR_DIRECTION_JOURNEY: self.data.journey.sections[0].informations.direction,
-            ATTR_DEPARTURE_TIME_JOURNEY: self.timezone.localize(self.data.journey.departure_date_time),
-            ATTR_ARRIVAL_TIME_JOURNEY: self.timezone.localize(self.data.journey.arrival_date_time),
+            ATTR_DEPARTURE_TIME_JOURNEY: self.data.journey.departure_date_time.replace(tzinfo=self.timezone),
+            ATTR_ARRIVAL_TIME_JOURNEY: self.data.journey.arrival_date_time.replace(tzinfo=self.timezone),
             ATTR_DURATION_JOURNEY: self.data.journey.sections[0].duration,
             ATTR_PHYSICAL_MODE_JOURNEY: self.data.journey.sections[0].informations.physical_mode,
             ATTR_DEPARTURE_JOURNEY: self.start_label,
@@ -87,11 +87,11 @@ class JourneyEntity(JourneyBaseEntity, SensorEntity):
     def __init__(self, coordinator, index, type):
         super().__init__(coordinator, index, type)
         self._attr_unique_id = f"{self.short_start_name()}_{self.short_end_name()}_journeys"
-        self._attr_native_value = self.timezone.localize(self.data.journey.departure_date_time)
+        self._attr_native_value = self.data.journey.departure_date_time.replace(tzinfo=self.timezone)
 
     def _handle_journey_update(self) -> None:
         _LOGGER.debug("[%s] updating: %s - %s", type(self).__name__, self.start_label, self.end_label)
-        self._attr_native_value = self.timezone.localize(self.data.journey.departure_date_time)
+        self._attr_native_value = self.data.journey.departure_date_time.replace(tzinfo=self.timezone)
         self.async_write_ha_state()
 
     @property
@@ -113,8 +113,8 @@ class JourneyEntity(JourneyBaseEntity, SensorEntity):
             journeys.append({
                 ATTR_LINE_JOURNEY: data.journey.sections[0].informations.label,
                 ATTR_DIRECTION_JOURNEY: data.journey.sections[0].informations.direction,
-                ATTR_DEPARTURE_TIME_JOURNEY: self.timezone.localize(data.journey.departure_date_time),
-                ATTR_ARRIVAL_TIME_JOURNEY: self.timezone.localize(data.journey.arrival_date_time),
+                ATTR_DEPARTURE_TIME_JOURNEY: data.journey.departure_date_time.replace(tzinfo=self.timezone),
+                ATTR_ARRIVAL_TIME_JOURNEY: data.journey.arrival_date_time.replace(tzinfo=self.timezone),
                 ATTR_DURATION_JOURNEY: data.journey.sections[0].duration,
                 ATTR_PHYSICAL_MODE_JOURNEY: data.journey.sections[0].informations.physical_mode,
                 ATTR_DEPARTURE_JOURNEY: self.start_label,
@@ -134,11 +134,11 @@ class DepartureEntity(JourneyBaseEntity, SensorEntity):
         super().__init__(coordinator, index, type)
 
         self._attr_unique_id = f"{self.short_start_name()}_{self.short_end_name()}_{self.type}_journey_departure_{self.index + 1}"
-        self._attr_native_value = self.timezone.localize(self.data.journey.departure_date_time)
+        self._attr_native_value = self.data.journey.departure_date_time.replace(tzinfo=self.timezone)
 
     def _handle_journey_update(self) -> None:
         _LOGGER.debug("[%s] updating: %s - %s", type(self).__name__, self.start_label, self.end_label)
-        self._attr_native_value = self.timezone.localize(self.data.journey.departure_date_time)
+        self._attr_native_value = self.data.journey.departure_date_time.replace(tzinfo=self.timezone)
         self.async_write_ha_state()
 
     @property
@@ -152,11 +152,11 @@ class ArrivalEntity(JourneyBaseEntity, SensorEntity):
         super().__init__(coordinator, index, type)
 
         self._attr_unique_id = f"{self.short_start_name()}_{self.short_end_name()}_{self.type}_journey_arrival_{self.index + 1}"
-        self._attr_native_value = self.timezone.localize(self.data.journey.arrival_date_time)
+        self._attr_native_value = self.data.journey.arrival_date_time.replace(tzinfo=self.timezone)
 
     def  _handle_journey_update(self) -> None:
         _LOGGER.debug("[%s] updating: %s - %s", type(self).__name__, self.start_label, self.end_label)
-        self._attr_native_value = self.timezone.localize(self.data.journey.arrival_date_time)
+        self._attr_native_value = self.data.journey.arrival_date_time.replace(tzinfo=self.timezone)
         self.async_write_ha_state()
 
     @property


### PR DESCRIPTION
Description:

This pull request replaces the use of the pytz library with Python’s built-in zoneinfo module inside coordinator.py.

🐛 Problem

Home Assistant logs the following warning when loading the integration: Detected blocking call to open (...) inside the event loop by custom integration 'train_traveler' at custom_components/train_traveler/coordinator.py, line 83:
    self._timezone = pytz.timezone("Europe/Paris")

This happens because pytz.timezone() performs a blocking file read (open()) to load time zone data, which freezes the asyncio event loop during initialization.

💡 Solution

Replaced pytz with zoneinfo:

ZoneInfo("Europe/Paris") replaces pytz.timezone("Europe/Paris")

datetime.timezone.utc replaces pytz.utc

Removed deprecated localize() call (not needed with ZoneInfo)

Adjusted datetime handling with .replace(tzinfo=self._timezone)

✅ Benefits

Eliminates blocking I/O inside the async loop

Fully compatible with Python 3.9+ and Home Assistant 2025+

Aligns with Home Assistant asyncio best practices